### PR TITLE
fix: 데이터베이스 스키마 필드명 수정 및 초기화 스크립트 개선

### DIFF
--- a/src/controllers/inbound.js
+++ b/src/controllers/inbound.js
@@ -1,9 +1,9 @@
 export const loginWorker = ({ body }) => {
-  const { worker_id, type } = body
+  const { worker_id, workType } = body
   // DB 저장 + 응답 반환
   return {
     message: 'Worker registered successfully',
-    assigned_type: type,
+    assigned_workType: workType,
     timestamp: new Date().toISOString()
   }
 }

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -32,7 +32,7 @@ CREATE TABLE workers (
     worker_id       VARCHAR(64) PRIMARY KEY,
     name            VARCHAR(100) NOT NULL,
     height          NUMERIC(5,2),
-    type            VARCHAR(2) NOT NULL CHECK (type IN ('IB', 'OB'))
+    workType        VARCHAR(2) NOT NULL CHECK (workType IN ('IB', 'OB'))
 );
 
 -- [3] totes
@@ -59,7 +59,7 @@ CREATE TABLE tote_items (
 CREATE TABLE picking_tasks (
     task_id             SERIAL PRIMARY KEY,
     tote_id             VARCHAR(64) NOT NULL,
-    type                VARCHAR(2) CHECK (type IN ('IB', 'OB')) NOT NULL,
+    workType            VARCHAR(2) CHECK (workType IN ('IB', 'OB')) NOT NULL,
     deadline            TIMESTAMP NOT NULL,
     assigned_worker_id  VARCHAR(64),
     status              VARCHAR(20) DEFAULT '대기',
@@ -108,10 +108,10 @@ GROUP BY product_id, to_location_id;
 CREATE OR REPLACE VIEW vw_blocked_rack AS
 SELECT DISTINCT
     CASE
-        WHEN pt.type = 'IB' THEN ti.to_location_id
+        WHEN pt.workType = 'IB' THEN ti.to_location_id
         ELSE ti.from_location_id
     END AS location_id,
-    pt.type
+    pt.workType
 FROM tote_items ti
 JOIN picking_tasks pt ON ti.tote_id = pt.tote_id
 WHERE pt.status IN ('대기', '진행');

--- a/src/db/seed.sql
+++ b/src/db/seed.sql
@@ -12,7 +12,7 @@ COPY outbound_list(outbound_id, product_id, deadline, status)
 FROM '/Users/kunwoopark/WS/KSEB-bootCamp/bun-control-server/src/db/csv/outbound_list.csv' DELIMITER ',' CSV HEADER;
 
 -- workers는 INSERT문
-INSERT INTO workers (worker_id, name, height, type) VALUES
+INSERT INTO workers (worker_id, name, height, workType) VALUES
 ('9334-4300', '김민수', 161.7, 'OB'),
 ('8667-2188', '이지은', 172.5, 'OB'),
 ('4187-5025', '박지훈', 181.5, 'OB'),


### PR DESCRIPTION
## 변경 사항
- `workers` 테이블의 `type` 필드를 `workType`으로 변경
- IB/OB 작업자 구분을 위한 필드명을 더 명확하게 개선

## 수정된 파일
- `src/db/schema.sql`: 테이블 생성 시 필드명 변경
- `src/db/seed.sql`: INSERT 문의 필드명 변경

## 이유
- `type`은 TS 예약어와 충돌할 수 있어 `workType`으로 변경
- 필드명이 더 직관적이고 명확해짐